### PR TITLE
Fix runtime requirements in the dist metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ author-email = "mail@pradyunsg.me"
 home-page = "https://github.com/pradyunsg/sphinx-inline-tabs"
 description-file = "README.md"
 requires-python = ">=3.6"
-requires = []
+requires = ["sphinx >= 3"]
 
 [tool.flit.metadata.requires-extra]
 test = [
@@ -17,4 +17,4 @@ test = [
   "pytest-cov",
   "pytest-xdist",
 ]
-doc = ["sphinx >= 3", "myst-parser", "furo"]
+doc = ["myst-parser", "furo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ author = "Pradyun Gedam"
 author-email = "mail@pradyunsg.me"
 home-page = "https://github.com/pradyunsg/sphinx-inline-tabs"
 description-file = "README.md"
-requires-python = ">=3.5"
+requires-python = ">=3.6"
 requires = []
 
 [tool.flit.metadata.requires-extra]


### PR DESCRIPTION
This change sets `requires-python` to be py3.6+ because `_impl.py` has f-strings so stating Python 3.5 support is incorrect. Moreover, f-strings are in place since the initial commit so this project never supported py35.

It also fixes #14 by declaring a runtime dependency on Sphinx v3+.