### PR TITLE
feat: allow tabs to be selected via URL

### DIFF
--- a/src/sphinx_inline_tabs/static/tabs.js
+++ b/src/sphinx_inline_tabs/static/tabs.js
@@ -2,6 +2,9 @@ var labels_by_text = {};
 
 function ready() {
   var li = document.getElementsByClassName("tab-label");
+  const urlParams = new URLSearchParams(window.location.search);
+  const tabs = urlParams.getAll("tabs");
+
   for (const label of li) {
     label.onclick = onLabelClick;
     const text = label.textContent;
@@ -9,6 +12,12 @@ function ready() {
       labels_by_text[text] = [];
     }
     labels_by_text[text].push(label);
+  }
+
+  for (const tab of tabs) {
+    for (label of labels_by_text[tab]) {
+      label.previousSibling.checked = true;
+    }
   }
 }
 


### PR DESCRIPTION
This allows `http://127.0.0.1:55466/index.html?tabs=Three` to work. If there are different categories of tabs, you can select each of them with multiple params, like `?tabs=1&tabs=a`. Closes #23.

FYI, I'd recommend removing the `python="3.8"` lines from the noxfile, the specific Python doesn't matter that much, and it breaks developers who don't have Python 3.8 still installed. (At least in such a way that nox can find it, nox doesn't support pyenv automatigically).
