### PR TITLE
Fix MyST dollarmath rendering

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,10 @@ extensions = [
 ]
 templates_path = ["_templates"]
 
+myst_enable_extensions = [
+    "dollarmath",
+]
+
 #
 # -- Options for extlinks ----------------------------------------------------
 #


### PR DESCRIPTION
Closes #43 

The relevant MyST extension was not previously enabled as required.

As mentioned in #43, I've tested this locally by building the docs without this change, and then making the change and seeing the issue be resolved. However, I didn't manage the installation via `flit` as expected, as I was getting an error trying to use flit. I instead installed the dependencies `by hand` in a `venv` created virtual environment since there are so few dependencies, it was straightforward to do so. I'm assuming CI etc. will provide reassurance in a repeatable/isolated install that this resolves the issue and doesn't introduce any new problem.