### PR TITLE
Use only `[tool.flit.metadata]` #45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,6 @@ test = [
 ]
 doc = ["myst-parser", "furo"]
 
-[project.urls]
+[tool.flit.metadata.urls]
 Documentation = "https://sphinx-inline-tabs.readthedocs.io"
 Source = "https://github.com/pradyunsg/sphinx-inline-tabs"


### PR DESCRIPTION
Closes #45

This fixes this error when building from source:

```none
Config error: Use [project] table for metadata or [tool.flit.metadata], not both.
```

See https://flit.pypa.io/en/latest/pyproject_toml.html#urls-subsection