### PR TITLE
Update project metadata

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,14 +1,15 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-24.04
+  tools:
+    python: "3.8"
 
 formats: [pdf]
 sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.8
   install:
     - method: pip
       path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ requires = ["flit_core>=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name          = "sphinx_inline_tabs"
-license       = "MIT"
+name = "sphinx_inline_tabs"
+license = "MIT"
 license-files = ["LICENSE"]
-readme        = "README.md"
-authors       = [{name = "Pradyun Gedam", email = "mail@pradyunsg.me"}]
+readme = "README.md"
+authors = [{name = "Pradyun Gedam", email = "mail@pradyunsg.me"}]
 requires-python = ">=3.8"
-dependencies    = ["sphinx>=3"]
+dependencies = ["sphinx>=3"]
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,18 @@
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core>=3.11,<4"]
 build-backend = "flit_core.buildapi"
 
-[tool.flit.metadata]
-module = "sphinx_inline_tabs"
-author = "Pradyun Gedam"
-author-email = "mail@pradyunsg.me"
-home-page = "https://github.com/pradyunsg/sphinx-inline-tabs"
-description-file = "README.md"
+[project]
+name          = "sphinx_inline_tabs"
+license       = "MIT"
+license-files = ["LICENSE"]
+readme        = "README.md"
+authors       = [{name = "Pradyun Gedam", email = "mail@pradyunsg.me"}]
 requires-python = ">=3.8"
-requires = ["sphinx >= 3"]
+dependencies    = ["sphinx>=3"]
+dynamic = ["version", "description"]
 
-[tool.flit.metadata.requires-extra]
+[project.optional-dependencies]
 test = [
   "pytest",
   "pytest-cov",
@@ -20,5 +21,5 @@ test = [
 doc = ["myst-parser", "furo"]
 
 [project.urls]
+Homepage = "https://github.com/pradyunsg/sphinx-inline-tabs"
 Documentation = "https://sphinx-inline-tabs.readthedocs.io"
-Source = "https://github.com/pradyunsg/sphinx-inline-tabs"


### PR DESCRIPTION
Convert "old" metadata from `[tool.flit.metadata]` to `[project]`.
https://flit.pypa.io/en/stable/pyproject_toml.html

Also add explicit license information and the license file to the sdist + wheel.

Project metadata diff (with flit `3.11`):
```diff
 ...
-Author: Pradyun Gedam
-Author-email: mail@pradyunsg.me
+Author-email: Pradyun Gedam <mail@pradyunsg.me>
+License-Expression: MIT
 License-File: LICENSE
-Requires-Dist: sphinx >= 3
+Requires-Dist: sphinx>=3
-Home-page: https://github.com/pradyunsg/sphinx-inline-tabs
+Project-URL: Documentation, https://sphinx-inline-tabs.readthedocs.io
+Project-URL: Homepage, https://github.com/pradyunsg/sphinx-inline-tabs
 ...
```