### PR TITLE
Docutils 0.22 compatibility

### DIFF
--- a/src/sphinx_inline_tabs/_impl.py
+++ b/src/sphinx_inline_tabs/_impl.py
@@ -23,7 +23,7 @@ class _GeneralHTMLTagElement(nodes.Element, nodes.General):
         attributes.pop("classes")
         attributes.pop("names")
         attributes.pop("dupnames")
-        attributes.pop("backrefs")
+        attributes.pop("backrefs", None)
 
         if node._endtag:
             text = translator.starttag(node, node._tagname, **attributes)


### PR DESCRIPTION
backrefs attribute no longer used.

---

With docutils-0.22:

```
  File "/usr/lib/python3.14/site-packages/sphinx/util/docutils.py", line 767, in dispatch_visit
    method(node)
    ~~~~~~^^^^^^
  File "/usr/lib/python3.14/site-packages/sphinx_inline_tabs/_impl.py", line 26, in visit
    attributes.pop("backrefs")
    ~~~~~~~~~~~~~~^^^^^^^^^^^^
KeyError: 'backrefs'
```

As:
https://github.com/executablebooks/sphinx-tabs/pull/207/files#diff-f0bff539dd194a33cb07b83b95276a9074f9bab1132fc0913fca30c0c860b195
