### PR TITLE
Drop support for Python 3.8-3.9, Sphinx 3-6

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 formats: [pdf]
 sphinx:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ license = "MIT"
 license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{name = "Pradyun Gedam", email = "mail@pradyunsg.me"}]
-requires-python = ">=3.8"
-dependencies = ["sphinx>=3"]
+requires-python = ">=3.10"
+dependencies = ["sphinx>=7"]
 dynamic = ["version", "description"]
 
 [project.optional-dependencies]

--- a/src/sphinx_inline_tabs/__init__.py
+++ b/src/sphinx_inline_tabs/__init__.py
@@ -10,7 +10,7 @@ __all__ = ["setup"]
 
 def setup(app: Sphinx):
     """Entry point for sphinx theming."""
-    app.require_sphinx("3.0")
+    app.require_sphinx("7.0")
 
     # We do imports from Sphinx, after validating the Sphinx version
     from ._impl import TabContainer, TabDirective, TabHtmlTransform, TabInput, TabLabel

--- a/src/sphinx_inline_tabs/_impl.py
+++ b/src/sphinx_inline_tabs/_impl.py
@@ -1,7 +1,6 @@
 """The actual implementation."""
 
 import itertools
-from typing import List
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -95,11 +94,11 @@ class TabHtmlTransform(SphinxPostTransform):
 
     def run(self):
         """Locate and replace `TabContainer`s."""
-        self.stack = []  # type: List[List[TabContainer]]
+        self.stack: list[list[TabContainer]] = []
         self.counter = itertools.count(start=0, step=1)
 
         matcher = NodeMatcher(TabContainer)
-        for node in self.document.traverse(matcher):  # type: TabContainer
+        for node in self.document.traverse(matcher):
             self._process_one_node(node)
 
         while self.stack:
@@ -153,7 +152,7 @@ class TabHtmlTransform(SphinxPostTransform):
         else:
             self.stack.append([node])
 
-    def finalize_set(self, tab_set: List[TabContainer], set_counter: int):
+    def finalize_set(self, tab_set: list[TabContainer], set_counter: int):
         """Add these TabContainers as a single-set-of-tabs."""
         assert tab_set
 


### PR DESCRIPTION
Python 3.8-3.9 are end-of-life.

I think supporting three versions of Sphinx (7-9) is plenty.

This matches what was added to CI in https://github.com/pradyunsg/sphinx-inline-tabs/pull/53.