### PR TITLE
fix traverse deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version", "description"]
 [project.optional-dependencies]
 test = [
   "beautifulsoup4",
+  "docutils==0.21.2",
   "myst-parser",
   "pytest",
   "pytest-cov",

--- a/src/sphinx_inline_tabs/_impl.py
+++ b/src/sphinx_inline_tabs/_impl.py
@@ -99,7 +99,7 @@ class TabHtmlTransform(SphinxPostTransform):
         self.counter = itertools.count(start=0, step=1)
 
         matcher = NodeMatcher(TabContainer)
-        for node in self.document.traverse(matcher):  # type: TabContainer
+        for node in list(self.document.findall(matcher)):  # type: TabContainer
             self._process_one_node(node)
 
         while self.stack:


### PR DESCRIPTION
fix
```
[calculus ] /home/zhongcx/sage/local/var/lib/sage/venv-python3.13.9/lib/python3.13/site-packages/sphinx_inline_tabs/_impl.py:94: DeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall().
```